### PR TITLE
feat(standardization): updated parameters for standardization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@ npm install --save-dev broccoli-postcss-single
 ```javascript
 var compileCSS = require('broccoli-postcss-single');
 
-var outputTree = compileCSS(inputTrees, inputFile, outputFile, plugins, map);
+var outputTree = compileCSS(inputTrees, inputFile, outputFile, options);
 ```
 
 - **`inputTrees`**: An array of trees that specify the directories used by Broccoli. If you have a single tree, pass `[tree]`.
 - **`inputFile`**: Relative path of the main CSS file to process.
-- **`outputFile`** Relative path of the output CSS file.
-- **`plugins`** An array of plugin objects to be used by Postcss (a minimum of 1 plugin is required). The supported object format is `module`: the plugin module itself, and `options`: an object of supported options for the given plugin.
-- **`map`** An object of options to describe how Postcss should [handle source maps](https://github.com/postcss/postcss/blob/master/docs/source-maps.md).
+- **`outputFile`**: Relative path of the output CSS file.
+- **`options`**:
+ - **`plugins`**: An array of plugin objects to be used by Postcss (a minimum of 1 plugin is required). The supported object format is `module`: the plugin module itself, and `options`: an object of supported options for the given plugin.
+ - **`map`**: An object of options to describe how Postcss should [handle source maps](https://github.com/postcss/postcss/blob/master/docs/source-maps.md).
 
 ## Example
 
@@ -34,16 +35,21 @@ var outputTree = compileCSS(inputTrees, inputFile, outputFile, plugins, map);
 var compileCSS = require('broccoli-postcss-single');
 var cssnext = require('cssnext');
 
-var plugins = [
-    {
-        module: cssnext,
-        options: {
-            browsers: ['last 2 version']
-        }
-    },
-];
+var options = {
+    plugins: [
+        {
+            module: cssnext,
+            options: {
+                browsers: ['last 2 version']
+              }
+        },
+    ],
+    map: {
+        inline: true
+    }
+};
 
-var outputTree = compileCSS(['styles'], 'app.css', 'app.css', plugins, map);
+var outputTree = compileCSS(['styles'], 'app.css', 'app.css', options);
 module.exports = outputTree;
 ```
 

--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ var includePathSearcher = require('include-path-searcher')
 var CachingWriter = require('broccoli-caching-writer')
 var postcss = require('postcss')
 
-function PostcssCompiler (inputTrees, inputFile, outputFile, plugins, map) {
+function PostcssCompiler (inputTrees, inputFile, outputFile, options, depricatedMap) {
   if (!(this instanceof PostcssCompiler)) {
-    return new PostcssCompiler(inputTrees, inputFile, outputFile, plugins, map)
+    return new PostcssCompiler(inputTrees, inputFile, outputFile, options, depricatedMap)
   }
 
   if (!Array.isArray(inputTrees)) {
@@ -19,9 +19,23 @@ function PostcssCompiler (inputTrees, inputFile, outputFile, plugins, map) {
 
   this.inputFile = inputFile
   this.outputFile = outputFile
-  this.plugins = plugins || []
-  this.map = map || {}
   this.warningStream = process.stderr
+
+  if (Array.isArray(options)) {
+    console.warn('passing in a plain plugin paramater is now depricated, please pass in plugins as an option.')
+    this.plugins = options
+  } else {
+    this.plugins = options.plugins
+  }
+
+  if (depricatedMap) {
+    console.warn('passing in a plain map paramater is now depricated, please pass in mapping settings as an option.')
+    this.map = depricatedMap
+  } else {
+    this.map = options.map
+  }
+  this.plugins = this.plugins || []
+  this.map = this.map || {}
 }
 
 PostcssCompiler.prototype = Object.create(CachingWriter.prototype)


### PR DESCRIPTION
The other preprocessors such as `broccoli-less-single`, `broccoli-stylus-single`, and `broccoli-sass-source-maps`. only pass in 4 parameters. In order to move toward standardization of the different processing plugins, I believe it would help if this plugin only used 4 parameters as well. 

I added support for existing usages, but included a warning message so that the upgrade story is more "frictionless".