### PR TITLE
fix missing caching options

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const postcss = require('postcss')
 
 function PostcssCompiler (inputNodes, inputFile, outputFile, _options) {
   var options = Object.assign({
-    cacheInclude: [/.*\.(js|css)$/]
+    cacheInclude: [/.*\.(css|scss|sass|less)$/]
   }, _options)
 
   if (!(this instanceof PostcssCompiler)) {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,11 @@ const includePathSearcher = require('include-path-searcher')
 const CachingWriter = require('broccoli-caching-writer')
 const postcss = require('postcss')
 
-function PostcssCompiler (inputNodes, inputFile, outputFile, options) {
+function PostcssCompiler (inputNodes, inputFile, outputFile, _options) {
+  var options = Object.assign({
+    cacheInclude: [/.*\.(js|css)$/]
+  }, _options)
+
   if (!(this instanceof PostcssCompiler)) {
     return new PostcssCompiler(inputNodes, inputFile, outputFile, options)
   }


### PR DESCRIPTION
allows configuring `cacheInclude` or `cacheExclude` with reasonable default value

this will at least prevent running Postcss on `hbs` file changes if I understand correctly.